### PR TITLE
fix: off by one bug when creating dice for a new parser

### DIFF
--- a/parse/parse.go
+++ b/parse/parse.go
@@ -64,7 +64,7 @@ func NewParser(s string) (*Parser, error) {
 		return nil, errors.Wrap(err, "failed to convert die signature to int")
 	}
 
-	for i := 0; i <= p.Quantity; i++ {
+	for i := 1; i <= p.Quantity; i++ {
 		// Apply die to formula
 		die, err := roll.NewDie(1, max)
 		if err != nil {

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -28,7 +28,7 @@ type Parser struct {
 	Modifier int
 }
 
-const pattern = `^(?P<quantity>\d+)(?P<die>d\d+)(?P<operator>[-+]?)(?P<modifier>\d+?)?$`
+const pattern = `^(?P<quantity>[1-9][0-9]*)(?P<die>d\d+)(?P<operator>[-+]?)(?P<modifier>\d+?)?$`
 
 func Match(s string) ([]string, error) {
 	regex, err := regexp.Compile(pattern)

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -13,26 +13,59 @@ func init() {
 }
 
 func TestMatch_valid(t *testing.T) {
-	t.Run("pattern is valid", func(t *testing.T) {
-		got := "1d12"
+	tests := []struct {
+		name  string
+		got   string
+		valid bool
+	}{
+		{
+			name: "pattern is valid",
+			got:  "1d12",
+		},
+		{
+			name: "pattern with addition modifier is valid",
+			got:  "1d6+3",
+		},
+		{
+			name: "pattern with subtraction modifier is valid",
+			got:  "1d6-3",
+		},
+	}
 
-		_, err := Match(got)
-		assert.NoError(t, err)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Match(tt.got)
+			assert.NoError(t, err)
+		})
+	}
+}
 
-	t.Run("pattern with addition modifier is valid", func(t *testing.T) {
-		got := "1d6+3"
+func TestMatch_invalid(t *testing.T) {
+	tests := []struct {
+		name  string
+		got   string
+		valid bool
+	}{
+		{
+			name: "pattern with no quantity is invalid",
+			got:  "d6",
+		},
+		{
+			name: "pattern with no quantity and modifier is invalid",
+			got:  "d6+1",
+		},
+		{
+			name: "pattern with zero quantity is invalid",
+			got:  "0d6",
+		},
+	}
 
-		_, err := Match(got)
-		assert.NoError(t, err)
-	})
-
-	t.Run("pattern with subtraction modifier is valid", func(t *testing.T) {
-		got := "1d12-3"
-
-		_, err := Match(got)
-		assert.NoError(t, err)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Match(tt.got)
+			assert.Error(t, err)
+		})
+	}
 }
 
 func TestMatch(t *testing.T) {

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -3,6 +3,7 @@ package parse
 import (
 	"testing"
 
+	"github.com/brittonhayes/roll"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 )
@@ -64,7 +65,15 @@ func TestMatch(t *testing.T) {
 func TestParser(t *testing.T) {
 	t.Run("create parser and roll", func(t *testing.T) {
 		p, err := NewParser("1d6+2")
+
 		if assert.NoError(t, err) {
+			assert.EqualValues(t, Parser{
+				Quantity: 1,
+				Dice:     []*roll.Die{{Min: 1, Max: 6}},
+				Operator: "+",
+				Modifier: 2},
+				*p)
+
 			assert.Positive(t, p.Roll())
 		}
 	})


### PR DESCRIPTION
Feel free to close this, I just love this little tool and found these two little things while I was playing around! 🎉 

Changed range loop bounds, added test that would have caught this. Also tweak the regex to not allow for a quantity of `0`, and add test coverage for that.

Failing test output before the change:
```
=== RUN   TestParser/create_parser_and_roll
    parse_test.go:103:
                Error Trace:    parse_test.go:103
                Error:          Not equal:
                                expected: parse.Parser{Quantity:1, Dice:[]*roll.Die{(*roll.Die)(0xc00041fee0)}, Operator:"+", Modifier:2}
                                actual  : parse.Parser{Quantity:1, Dice:[]*roll.Die{(*roll.Die)(0xc00041fe80), (*roll.Die)(0xc00041feb0)}, Operator:"+", Modifier:2}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -2,3 +2,7 @@
                                  Quantity: (int) 1,
                                - Dice: ([]*roll.Die) (len=1) {
                                + Dice: ([]*roll.Die) (len=2) {
                                +  (*roll.Die)({
                                +   Min: (int) 1,
                                +   Max: (int) 6
                                +  }),
                                   (*roll.Die)({
                Test:           TestParser/create_parser_and_roll
```

incorrect cli output before
```
❯ go run cmd/roll/main.go -v 1d6
1:30AM INF found "1 D6  0"
1:30AM INF rolled 2 with D6
1:30AM INF rolled 5 with D6
🎲 7
```

correct cli output after
```
❯ go run cmd/roll/main.go -v 1d6
1:39AM INF found "1 D6  0"
1:39AM INF rolled 4 with D6
🎲 4
```